### PR TITLE
Support for adding descriptions in body params

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -60,6 +60,7 @@ module Rswag
                   if value && schema_param && mime_list
                     value[:requestBody] = { content: {} } unless value.dig(:requestBody, :content)
                     value[:requestBody][:required] = true if schema_param[:required]
+                    value[:requestBody][:description] = schema_param[:description] if schema_param[:description]
                     mime_list.each do |mime|
                       value[:requestBody][:content][mime] = { schema: schema_param[:schema] }
                     end

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -368,6 +368,30 @@ module Rswag
           end
         end
 
+        context 'with descriptions on the body param' do
+          let(:doc_2) do
+            {
+              paths: {
+                '/path/' => {
+                  post: {
+                    produces: ['application/json'],
+                    consumes: ['application/json'],
+                    parameters: [{
+                      in: :body,
+                      description: "description",
+                      schema: { type: :number }
+                    }]
+                  }
+                }
+              }
+            }
+          end
+
+          it 'puts the description in the doc' do
+            expect(doc_2[:paths]['/path/'][:post][:requestBody][:description]).to eql('description')
+          end
+        end
+
         after do
           FileUtils.rm_r(swagger_root) if File.exist?(swagger_root)
         end

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -125,7 +125,13 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       description 'Upload a thumbnail for specific blog by id'
       operationId 'uploadThumbnailBlog'
       consumes 'multipart/form-data'
-      parameter name: :file, :in => :formData, :type => :file, required: true
+      parameter(
+        name: :file,
+        description: "description",
+        in: :formData,
+        type: :file,
+        required: true
+      )
 
       response '200', 'blog updated' do
         let(:file) { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/thumbnail.png")) }

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       consumes 'multipart/form-data'
       parameter(
         name: :file,
-        description: "description",
+        description: "The content of the blog thumbnail",
         in: :formData,
         type: :file,
         required: true

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -273,7 +273,8 @@
               }
             }
           },
-          "required": true
+          "required": true,
+          "description": "description"
         }
       }
     }


### PR DESCRIPTION
Taking this PR from the upstream repo because I would like to be able to use this in my Fork

> Addresses #403 - I'm not sure I understand how the tests assert their behavior, but I pattern-matched and the change locally appears to perform as expected. Any suggestions?