### PR TITLE
Support for adding descriptions in body params

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,11 +610,7 @@ To enable examples generation from responses add callback above run_test! like:
 
 ```
 after do |example|
-  example.metadata[:response][:content] = {
-    'application/json' => {
-      example: JSON.parse(response.body, symbolize_names: true)
-    }
-  }
+  example.example_group.example_value JSON.parse(response.body, symbolize_names: true)
 end
 ```
 

--- a/rswag-specs/lib/generators/rspec/templates/spec.rb
+++ b/rswag-specs/lib/generators/rspec/templates/spec.rb
@@ -19,11 +19,7 @@ RSpec.describe '<%= controller_path %>', type: :request do
 <%      end -%>
 
         after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
+          example.example_group.example_value JSON.parse(response.body, symbolize_names: true)
         end
         run_test!
       end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/string/inflections'
+
 module Rswag
   module Specs
     module ExampleGroupHelpers
@@ -52,8 +54,19 @@ module Rswag
       end
 
       def response(code, description, metadata = {}, &block)
-        metadata[:response] = { code: code, description: description }
+        metadata[:response] = { code: code, description: description, examples: {} }
         context(description, metadata, &block)
+      end
+
+      def example_context(description, metadata = {}, &block)
+        context(description, metadata.merge(skip_formatter: true), &block)
+      end
+
+      def example_value(value)
+        metadata[:response][:examples][metadata[:description].parameterize separator: '_'] = {
+          summary: metadata[:description],
+          value: value
+        }
       end
 
       def schema(value)

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/hash/deep_merge'
+require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/object/blank'
 require 'rspec/core/formatters/base_text_formatter'
 require 'swagger_helper'
 
@@ -31,7 +33,7 @@ module Rswag
         # !metadata[:document] won't work, since nil means we should generate
         # docs.
         return if metadata[:document] == false
-        return unless metadata.key?(:response)
+        return unless metadata.key?(:response) && !metadata[:skip_formatter]
 
         swagger_doc = @config.get_swagger_doc(metadata[:swagger_doc])
 
@@ -127,17 +129,17 @@ module Rswag
         mime_list = Array(metadata[:operation][:produces] || swagger_doc[:produces])
         target_node = metadata[:response]
         upgrade_content!(mime_list, target_node)
-        metadata[:response].delete(:schema)
       end
 
       def upgrade_content!(mime_list, target_node)
-        schema = target_node[:schema]
-        return if mime_list.empty? || schema.nil?
+        target_node.merge!(content: {})
+        per_mime_data = target_node.extract!(:schema, :example, :examples).reject { |_, v| v.blank? }
+        return if mime_list.empty? || per_mime_data.empty?
 
         target_node[:content] ||= {}
         mime_list.each do |mime_type|
-          # TODO upgrade to have content-type specific schema
-          (target_node[:content][mime_type] ||= {}).merge!(schema: schema)
+          # TODO upgrade to have content-type specific data
+          target_node[:content][mime_type] = per_mime_data
         end
       end
 

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -111,7 +111,7 @@ module Rswag
 
         it "delegates to 'context' with 'response' metadata" do
           expect(subject).to have_received(:context).with(
-            'success', response: { code: '201', description: 'success' }
+            'success', response: { code: '201', description: 'success', examples: {} }
           )
         end
       end


### PR DESCRIPTION
Another PR I am stealing from Upstream. I really like this one!

> For example:
> 
>   after do |example|
>     example.example_group.example_value JSON.parse(response.body, symbolize_names: true) if response
>   end
> 
>   response 422, 'invalid request' do
>     example_context 'name is missing'
>       let(:password) { 'secret' }
>       run_test!
>     end
> 
>     example_context 'password is missing' do
>       let(:name) { 'bobby' }
>       run_test!
>     end
> 
>     example_context 'bad content type' do
>       example_value(
>         error: 'bad content type'
>       )
>     end
>   end
> 
> Annoyingly you still need a dummy RSpec example to include a static example
> value on its own but that's a limitation of RSwag's design.